### PR TITLE
Refactor translation pipeline to use translator microservice

### DIFF
--- a/airflow/dags/translation_pipeline.py
+++ b/airflow/dags/translation_pipeline.py
@@ -1,704 +1,569 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+"""Airflow DAG for Stage 3 translation orchestrated via the translator microservice."""
 
-"""
-✅ ПЕРЕРАБОТАННЫЙ Translation Pipeline v3.0 - Упрощенная архитектура
-Встроенная логика перевода без внешних зависимостей, оптимизированная для китайских документов
+from __future__ import annotations
 
-КЛЮЧЕВЫЕ ИЗМЕНЕНИЯ:
-- ✅ Убрана зависимость от vLLM микросервиса
-- ✅ Встроенные правила перевода
-- ✅ Сохранение технических терминов
-- ✅ Простая но эффективная логика
-"""
-
-from datetime import datetime, timedelta
-from airflow import DAG
-from airflow.operators.python import PythonOperator
-from airflow.exceptions import AirflowException, AirflowSkipException
-import os
 import json
 import logging
-import time
+import os
 import re
-from typing import Dict, Any, Optional, List
+import time
+from datetime import datetime, timedelta
+from statistics import mean
+from typing import Any, Dict, List, Optional
 
-# Утилиты
-from shared_utils import (
-    SharedUtils, NotificationUtils, ConfigUtils, 
-    MetricsUtils, ErrorHandlingUtils
-)
+import requests
+from airflow import DAG
+from airflow.exceptions import AirflowSkipException
+from airflow.operators.python import PythonOperator
+from requests.adapters import HTTPAdapter
 
-# Настройка логирования
+from shared_utils import ConfigUtils, MetricsUtils, NotificationUtils
+
 logger = logging.getLogger(__name__)
 
-# Конфигурация DAG
 DEFAULT_ARGS = {
-    'owner': 'pdf-converter',
-    'depends_on_past': False,
-    'start_date': datetime(2024, 1, 1),
-    'email_on_failure': False,
-    'email_on_retry': False,
-    'retries': 2,
-    'retry_delay': timedelta(minutes=3),
+    "owner": "pdf-converter",
+    "depends_on_past": False,
+    "start_date": datetime(2024, 1, 1),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 2,
+    "retry_delay": timedelta(minutes=3),
 }
 
 dag = DAG(
-    'translation_pipeline',
+    "translation_pipeline",
     default_args=DEFAULT_ARGS,
-    description='DAG 3: Translation Pipeline v3.0 - Упрощенный перевод для китайских документов',
+    description="Stage 3 translation pipeline using the translator microservice",
     schedule_interval=None,
     max_active_runs=2,
     catchup=False,
-    tags=['pdf-converter', 'dag3', 'translation', 'chinese-docs', 'v3']
+    tags=["pdf-converter", "stage3", "translation", "vllm"],
 )
 
-# ================================================================================
-# СЛОВАРИ ДЛЯ ПЕРЕВОДА КИТАЙСКИХ ТЕХНИЧЕСКИХ ДОКУМЕНТОВ
-# ================================================================================
+_service_urls = ConfigUtils.get_service_urls()
 
-# Технические термины (НЕ ПЕРЕВОДЯТСЯ)
-TECHNICAL_TERMS = {
-    # Бренды (КРИТИЧЕСКИ ВАЖНО!)
-    "问天": "WenTian",
-    "联想问天": "Lenovo WenTian",
-    "天擎": "ThinkSystem",
-    "AnyBay": "AnyBay",
-    
-    # Процессоры
-    "至强": "Xeon",
-    "可扩展处理器": "Scalable Processors",
-    "英特尔": "Intel",
-    
-    # Технические спецификации
-    "处理器": "Processor",
-    "内核": "Core", 
-    "线程": "Thread",
-    "睿频": "Turbo Boost",
-    "内存": "Memory",
-    "存储": "Storage",
-    "硬盘": "Drive",
-    "固态硬盘": "SSD",
-    "机械硬盘": "HDD",
-    "热插拔": "Hot-swap",
-    "冗余": "Redundancy",
-    "背板": "Backplane",
-    "托架": "Tray",
-    "以太网": "Ethernet",
-    "光纤": "Fiber",
-    "带宽": "Bandwidth",
-    "延迟": "Latency",
-    "网卡": "Network Adapter",
-    "英寸": "inch",
-    "机架": "Rack",
-    "插槽": "Slot",
-    "转接卡": "Riser Card",
-    "电源": "Power Supply",
-    "铂金": "Platinum",
-    "钛金": "Titanium",
-    "CRPS": "CRPS"
+TRANSLATION_CONFIG: Dict[str, Any] = {
+    "service_url": os.getenv("TRANSLATOR_URL", _service_urls.get("translator", "http://translator:8002")),
+    "endpoint": os.getenv("TRANSLATION_ENDPOINT", "/api/v1/translate"),
+    "timeout": int(os.getenv("TRANSLATION_TIMEOUT", "300")),
+    "max_retries": int(os.getenv("TRANSLATION_MAX_RETRIES", "3")),
+    "retry_delay": float(os.getenv("TRANSLATION_RETRY_DELAY", "5")),
+    "max_chars_per_chunk": int(os.getenv("TRANSLATION_MAX_CHARS", "3500")),
+    "model": os.getenv("VLLM_TRANSLATION_MODEL", "Qwen/Qwen3-30B-A3B-Instruct-2507"),
 }
 
-# Русские переводы
-CHINESE_TO_RUSSIAN = {
-    # Общие термины
-    "文档": "документ",
-    "技术": "технический",
-    "规格": "спецификация",
-    "说明": "описание",
-    "安装": "установка",
-    "配置": "конфигурация",
-    "管理": "управление",
-    "监控": "мониторинг",
-    "维护": "обслуживание",
-    "故障": "неисправность",
-    "排除": "устранение",
-    "性能": "производительность",
-    "优化": "оптимизация",
-    "升级": "обновление",
-    "兼容": "совместимость",
-    "支持": "поддержка",
-    "推荐": "рекомендуется",
-    "要求": "требования",
-    "注意": "внимание",
-    "警告": "предупреждение",
-    "重要": "важно",
-    
-    # Цифры и единицы
-    "个": "",  # счетное слово
-    "台": "шт.",
-    "套": "комплект",
-    "只": "шт.",
-    "条": "шт.",
-    "根": "шт.",
-    
-    # Таблицы и списки
-    "表": "таблица",
-    "列表": "список",
-    "项目": "элемент",
-    "选项": "опция",
-    "参数": "параметр",
-    "值": "значение",
-    "默认": "по умолчанию",
-    "可选": "опционально",
-    "必须": "обязательно",
-    
-    # Действия
-    "点击": "нажмите",
-    "选择": "выберите",  
-    "输入": "введите",
-    "确认": "подтвердите",
-    "取消": "отмените",
-    "保存": "сохраните",
-    "删除": "удалите",
-    "修改": "измените",
-    "添加": "добавьте",
-    "移除": "удалите"
+BATCH_CONFIG: Dict[str, int] = {
+    "headers": max(1, int(os.getenv("BATCH_SIZE_HEADERS", "4"))),
+    "tables": max(1, int(os.getenv("BATCH_SIZE_TABLES", "3"))),
+    "commands": max(1, int(os.getenv("BATCH_SIZE_COMMANDS", "2"))),
+    "text": max(1, int(os.getenv("BATCH_SIZE_TEXT", "6"))),
+    "mixed": max(1, int(os.getenv("BATCH_SIZE_MIXED", "4"))),
+    "technical": max(1, int(os.getenv("BATCH_SIZE_TECHNICAL", os.getenv("BATCH_SIZE_TEXT", "6")))),
 }
 
-# Английские переводы
-CHINESE_TO_ENGLISH = {
-    # Общие термины
-    "文档": "document",
-    "技术": "technical",
-    "规格": "specification",
-    "说明": "description",
-    "安装": "installation",
-    "配置": "configuration",
-    "管理": "management",
-    "监控": "monitoring", 
-    "维护": "maintenance",
-    "故障": "fault",
-    "排除": "troubleshooting",
-    "性能": "performance",
-    "优化": "optimization",
-    "升级": "upgrade",
-    "兼容": "compatibility",
-    "支持": "support",
-    "推荐": "recommended",
-    "要求": "requirements",
-    "注意": "note",
-    "警告": "warning",
-    "重要": "important",
-    
-    # Единицы измерения
-    "个": "",
-    "台": "units",
-    "套": "set",
-    "只": "piece",
-    "条": "item",
-    "根": "piece",
-    
-    # Таблицы и списки
-    "表": "table",
-    "列表": "list", 
-    "项目": "item",
-    "选项": "option",
-    "参数": "parameter",
-    "值": "value",
-    "默认": "default",
-    "可选": "optional",
-    "必须": "required",
-    
-    # Действия
-    "点击": "click",
-    "选择": "select",
-    "输入": "enter",
-    "确认": "confirm",
-    "取消": "cancel",
-    "保存": "save",
-    "删除": "delete",
-    "修改": "modify",
-    "添加": "add",
-    "移除": "remove"
-}
+_TRANSLATOR_SESSION = requests.Session()
+_TRANSLATOR_ADAPTER = HTTPAdapter(pool_connections=4, pool_maxsize=8)
+_TRANSLATOR_SESSION.mount("http://", _TRANSLATOR_ADAPTER)
+_TRANSLATOR_SESSION.mount("https://", _TRANSLATOR_ADAPTER)
 
-# ================================================================================
-# ОСНОВНЫЕ ФУНКЦИИ ПЕРЕВОДА
-# ================================================================================
 
-def initialize_translation(**context) -> Dict[str, Any]:
-    """Инициализация процесса перевода"""
-    start_time = time.time()
-    
-    try:
-        dag_run_conf = context['dag_run'].conf or {}
-        logger.info(f"🌐 Инициализация перевода: {json.dumps(dag_run_conf, indent=2, ensure_ascii=False)}")
+def _normalize_newlines(text: str) -> str:
+    return text.replace("\r\n", "\n").replace("\r", "\n")
 
-        # Новое: корректный пропуск Stage 3 по флагу
-        if dag_run_conf.get('skip_stage3', False):
-            raise AirflowSkipException("Stage 3 skipped by orchestrator (no translation required)")
-        
-        # Получение Markdown файла
-        markdown_file = dag_run_conf.get('markdown_file')
-        if not markdown_file or not os.path.exists(markdown_file):
-            raise ValueError(f"Markdown файл не найден: {markdown_file}")
-        
-        # Чтение контента
-        with open(markdown_file, 'r', encoding='utf-8') as f:
-            markdown_content = f.read()
-        
-        if not markdown_content.strip():
-            raise ValueError("Нет контента для перевода")
-        
-        original_config = dag_run_conf.get('original_config', {})
-        target_language = original_config.get('target_language', 'ru')
-        
-        # Инициализация сессии перевода
-        translation_session = {
-            'session_id': f"translation_{int(time.time())}",
-            'source_language': 'zh-CN',
-            'target_language': target_language,
-            'markdown_content': markdown_content,
-            'markdown_file': markdown_file,
-            'original_config': original_config,
-            'preserve_technical_terms': dag_run_conf.get('preserve_technical_terms', True),
-            'chinese_source': dag_run_conf.get('chinese_source', True),
-            'lines_total': len(markdown_content.split('\n')),
-            'processing_start_time': datetime.now().isoformat()
-        }
-        
-        MetricsUtils.record_processing_metrics(
-            dag_id='translation_pipeline',
-            task_id='initialize_translation',
-            processing_time=time.time() - start_time,
-            success=True
-        )
-        
-        logger.info(f"✅ Перевод инициализирован: {target_language} ({translation_session['lines_total']} строк)")
-        return translation_session
-        
-    except Exception as e:
-        MetricsUtils.record_processing_metrics(
-            dag_id='translation_pipeline',
-            task_id='initialize_translation',
-            processing_time=time.time() - start_time,
-            success=False
-        )
-        logger.error(f"❌ Ошибка инициализации перевода: {e}")
-        raise
 
-def perform_translation(**context) -> Dict[str, Any]:
-    """Выполнение перевода документа"""
-    start_time = time.time()
-    session = context['task_instance'].xcom_pull(task_ids='initialize_translation')
-    
-    try:
-        markdown_content = session['markdown_content']
-        target_language = session['target_language']
-        
-        logger.info(f"🔄 Начинаем перевод на {target_language}")
-        
-        # Выбираем словарь перевода
-        if target_language == 'ru':
-            translation_dict = CHINESE_TO_RUSSIAN
-        elif target_language == 'en':
-            translation_dict = CHINESE_TO_ENGLISH
-        else:
-            # Для неподдерживаемых языков возвращаем оригинал
-            logger.warning(f"Язык {target_language} не поддерживается, возвращаем оригинал")
-            translation_dict = {}
-        
-        if target_language == 'original' or target_language == 'zh':
-            # Возвращаем оригинальный китайский контент
-            translated_content = markdown_content
-        else:
-            # Выполняем перевод
-            translated_content = translate_content(
-                markdown_content, 
-                translation_dict, 
-                target_language,
-                session.get('preserve_technical_terms', True)
+def classify_line(line: str) -> str:
+    stripped = line.strip()
+    if not stripped:
+        return "empty"
+    if stripped.startswith("#"):
+        return "header"
+    if stripped.startswith("|"):
+        return "table"
+    if stripped.startswith("```"):
+        return "code"
+    if re.search(r"`[^`]+`", stripped):
+        return "inline_code"
+    if re.search(r"\\b(ipmitool|chassis|power|cli|bios|efi)\\b", stripped, re.IGNORECASE):
+        return "command"
+    if re.search(r"\\b\\d+(?:\\.\\d+)?\\s*(GB|TB|GHz|MHz|W|%)\\b", stripped):
+        return "technical"
+    return "text"
+
+
+def get_batch_size(content_type: str) -> int:
+    if content_type == "header":
+        return BATCH_CONFIG["headers"]
+    if content_type == "table":
+        return BATCH_CONFIG["tables"]
+    if content_type in {"command", "inline_code"}:
+        return BATCH_CONFIG["commands"]
+    if content_type == "technical":
+        return BATCH_CONFIG["technical"]
+    if content_type == "code":
+        return 1
+    return BATCH_CONFIG["text"]
+
+
+def build_translation_batches(content: str) -> List[Dict[str, str]]:
+    normalized = _normalize_newlines(content)
+    lines = normalized.split("\n")
+    batches: List[Dict[str, str]] = []
+    idx = 0
+
+    while idx < len(lines):
+        current_line = lines[idx]
+        if not current_line.strip():
+            batches.append({"type": "raw", "content": current_line})
+            idx += 1
+            continue
+
+        content_type = classify_line(current_line)
+        batch_limit = get_batch_size(content_type)
+        chunk_lines: List[str] = []
+        char_count = 0
+
+        while idx < len(lines):
+            line = lines[idx]
+            if not line.strip():
+                break
+
+            line_type = classify_line(line)
+            if chunk_lines and line_type != content_type:
+                break
+
+            prospective = char_count + len(line) + 1
+            if chunk_lines and (len(chunk_lines) >= batch_limit or prospective > TRANSLATION_CONFIG["max_chars_per_chunk"]):
+                break
+
+            chunk_lines.append(line)
+            char_count = prospective
+            idx += 1
+
+            if len(chunk_lines) >= batch_limit:
+                break
+
+        if chunk_lines:
+            batches.append({
+                "type": "translatable",
+                "content": "\n".join(chunk_lines),
+            })
+            continue
+
+        batches.append({"type": "raw", "content": current_line})
+        idx += 1
+
+    return batches
+
+
+def call_translator_with_retries(
+    text: str,
+    source_lang: str,
+    target_lang: str,
+    stats: Dict[str, Any],
+    chunk_index: int,
+    total_chunks: int,
+) -> Optional[str]:
+    url = f"{TRANSLATION_CONFIG['service_url'].rstrip('/')}{TRANSLATION_CONFIG['endpoint']}"
+    payload = {
+        "text": text,
+        "source_lang": source_lang,
+        "target_lang": target_lang,
+    }
+
+    last_error: Optional[Exception] = None
+
+    for attempt in range(1, TRANSLATION_CONFIG["max_retries"] + 1):
+        try:
+            logger.info(
+                "🌐 Отправка чанка %s/%s в translator service (попытка %s)",
+                chunk_index + 1,
+                total_chunks,
+                attempt,
             )
-        
-        # Постобработка перевода
-        final_content = post_process_translation(translated_content, target_language)
-        
-        # Валидация качества
-        quality_score = validate_translation_quality(
-            markdown_content, 
-            final_content, 
-            target_language
-        )
-        
-        translation_results = {
-            'translated_content': final_content,
-            'source_length': len(markdown_content),
-            'translated_length': len(final_content),
-            'quality_score': quality_score,
-            'translation_stats': {
-                'processing_time_seconds': time.time() - start_time,
-                'translation_method': 'builtin_dictionary_v3',
-                'chinese_chars_remaining': count_chinese_characters(final_content),
-                'technical_terms_preserved': count_preserved_technical_terms(final_content)
-            }
-        }
-        
-        MetricsUtils.record_processing_metrics(
-            dag_id='translation_pipeline',
-            task_id='perform_translation',
-            processing_time=time.time() - start_time,
-            success=True
-        )
-        
-        logger.info(f"✅ Перевод завершен. Качество: {quality_score:.1f}%")
-        return translation_results
-        
-    except Exception as e:
-        MetricsUtils.record_processing_metrics(
-            dag_id='translation_pipeline',
-            task_id='perform_translation',
-            processing_time=time.time() - start_time,
-            success=False
-        )
-        logger.error(f"❌ Ошибка выполнения перевода: {e}")
-        raise
+            start = time.time()
+            response = _TRANSLATOR_SESSION.post(
+                url,
+                json=payload,
+                timeout=TRANSLATION_CONFIG["timeout"],
+            )
+            latency = time.time() - start
+            stats.setdefault("latencies", []).append(latency)
+            stats["api_calls"] += 1
 
-def translate_content(content: str, translation_dict: Dict[str, str], target_lang: str, preserve_terms: bool = True) -> str:
-    """Основная функция перевода контента"""
-    try:
-        # Сначала сохраняем технические термины
-        if preserve_terms:
-            for chinese_term, english_term in TECHNICAL_TERMS.items():
-                if chinese_term in content:
-                    # Заменяем китайские термины на английские аналоги
-                    content = content.replace(chinese_term, english_term)
-        
-        # Применяем словарь перевода
-        for chinese_phrase, translation in translation_dict.items():
-            if chinese_phrase in content and translation:
-                content = content.replace(chinese_phrase, translation)
-        
-        # Специальная обработка для заголовков
-        content = translate_chinese_headings(content, target_lang)
-        
-        # Обработка таблиц
-        content = translate_table_content(content, translation_dict)
-        
-        return content
-        
-    except Exception as e:
-        logger.warning(f"Ошибка перевода контента: {e}")
-        return content
+            if response.status_code == 200:
+                data = response.json()
+                stats["successful_requests"] += 1
+                logger.info(
+                    "✅ Чанк %s/%s переведен за %.2fs",
+                    chunk_index + 1,
+                    total_chunks,
+                    latency,
+                )
+                return data.get("translated_content", text)
 
-def translate_chinese_headings(content: str, target_lang: str) -> str:
-    """Перевод китайских заголовков"""
-    try:
-        lines = content.split('\n')
-        translated_lines = []
-        
-        heading_translations = {
-            'ru': {
-                '第': 'Глава',
-                '章': '',
-                '节': 'Раздел',
-                '部分': 'Часть',
-                '概述': 'Обзор',
-                '介绍': 'Введение',
-                '总结': 'Заключение',
-                '附录': 'Приложение'
-            },
-            'en': {
-                '第': 'Chapter',
-                '章': '',
-                '节': 'Section',
-                '部分': 'Part',
-                '概述': 'Overview',
-                '介绍': 'Introduction',
-                '总结': 'Summary',
-                '附录': 'Appendix'
-            }
-        }
-        
-        translations = heading_translations.get(target_lang, {})
-        
-        for line in lines:
-            if line.strip().startswith('#'):
-                # Это заголовок - переводим его содержимое
-                for chinese, translation in translations.items():
-                    if chinese in line and translation:
-                        line = line.replace(chinese, translation)
-            
-            translated_lines.append(line)
-        
-        return '\n'.join(translated_lines)
-        
-    except Exception as e:
-        logger.warning(f"Ошибка перевода заголовков: {e}")
-        return content
+            stats["failed_requests"] += 1
+            last_error = RuntimeError(
+                f"Unexpected status {response.status_code}: {response.text[:200]}"
+            )
+            logger.warning("⚠️ Ошибка перевода чанка %s/%s: %s", chunk_index + 1, total_chunks, last_error)
+        except requests.RequestException as exc:
+            stats["failed_requests"] += 1
+            last_error = exc
+            logger.warning(
+                "⚠️ Сетевая ошибка при переводе чанка %s/%s: %s",
+                chunk_index + 1,
+                total_chunks,
+                exc,
+            )
+        stats["retries"] += 1
+        if attempt < TRANSLATION_CONFIG["max_retries"]:
+            sleep_for = TRANSLATION_CONFIG["retry_delay"] * attempt
+            logger.info("⏳ Повтор через %.1fs", sleep_for)
+            time.sleep(sleep_for)
 
-def translate_table_content(content: str, translation_dict: Dict[str, str]) -> str:
-    """Перевод содержимого таблиц"""
-    try:
-        lines = content.split('\n')
-        translated_lines = []
-        
-        for line in lines:
-            if '|' in line and len(line.split('|')) >= 3:
-                # Это строка таблицы - переводим содержимое ячеек
-                cells = line.split('|')
-                translated_cells = []
-                
-                for cell in cells:
-                    cell_content = cell.strip()
-                    # Применяем переводы к содержимому ячеек
-                    for chinese, translation in translation_dict.items():
-                        if chinese in cell_content and translation:
-                            cell_content = cell_content.replace(chinese, translation)
-                    translated_cells.append(cell_content)
-                
-                line = '|'.join(translated_cells)
-            
-            translated_lines.append(line)
-        
-        return '\n'.join(translated_lines)
-        
-    except Exception as e:
-        logger.warning(f"Ошибка перевода таблиц: {e}")
-        return content
+    logger.error("❌ Не удалось перевести чанк %s/%s: %s", chunk_index + 1, total_chunks, last_error)
+    return None
 
-def post_process_translation(content: str, target_lang: str) -> str:
-    """Постобработка переведенного контента"""
-    try:
-        # Очистка лишних пробелов
-        content = re.sub(r'\n\s*\n\s*\n+', '\n\n', content)
-        
-        # Исправление пунктуации для русского языка
-        if target_lang == 'ru':
-            # Замена точек на правильную пунктуацию
-            content = re.sub(r'\.([А-Я])', r'. \1', content)
-            # Исправление кавычек
-            content = content.replace('"', '«').replace('"', '»')
-        
-        # Исправление технических терминов в скобках
-        content = re.sub(r'\(\s*([A-Za-z0-9]+)\s*\)', r' (\1)', content)
-        
-        return content.strip()
-        
-    except Exception as e:
-        logger.warning(f"Ошибка постобработки: {e}")
-        return content
-
-def validate_translation_quality(original: str, translated: str, target_lang: str) -> float:
-    """Валидация качества перевода"""
-    try:
-        quality_score = 100.0
-        
-        # Для оригинального китайского - максимальный балл
-        if target_lang in ['original', 'zh']:
-            return 100.0
-        
-        # Проверка длины
-        length_ratio = len(translated) / max(len(original), 1)
-        if length_ratio < 0.5 or length_ratio > 2.0:
-            quality_score -= 15
-        
-        # Проверка сохранения технических терминов
-        preserved_terms = count_preserved_technical_terms(translated)
-        original_terms = count_chinese_technical_terms(original)
-        
-        if original_terms > 0:
-            term_preservation = min(1.0, preserved_terms / original_terms)
-            quality_score += term_preservation * 10
-        
-        # Проверка структуры (заголовки, таблицы)
-        original_headers = len(re.findall(r'^#+\s', original, re.MULTILINE))
-        translated_headers = len(re.findall(r'^#+\s', translated, re.MULTILINE))
-        
-        if original_headers > 0:
-            header_preservation = translated_headers / original_headers
-            if header_preservation < 0.9:
-                quality_score -= 10
-        
-        # Проверка китайских символов (должно быть меньше в переводе)
-        chinese_remaining = count_chinese_characters(translated)
-        chinese_original = count_chinese_characters(original)
-        
-        if chinese_original > 0:
-            chinese_reduction = 1 - (chinese_remaining / chinese_original)
-            quality_score += chinese_reduction * 20
-        
-        return max(0, min(100, quality_score))
-        
-    except Exception:
-        return 75.0  # Средняя оценка по умолчанию
 
 def count_chinese_characters(text: str) -> int:
-    """Подсчет китайских символов"""
-    return len(re.findall(r'[\u4e00-\u9fff]', text))
+    return len(re.findall(r"[\u4e00-\u9fff]", text))
 
-def count_preserved_technical_terms(text: str) -> int:
-    """Подсчет сохраненных технических терминов"""
-    count = 0
-    for term in TECHNICAL_TERMS.values():
-        count += text.count(term)
-    return count
 
-def count_chinese_technical_terms(text: str) -> int:
-    """Подсчет китайских технических терминов"""
-    count = 0
-    for term in TECHNICAL_TERMS.keys():
-        count += text.count(term)
-    return count
-
-def save_translation_result(**context) -> Dict[str, Any]:
-    """Сохранение результата перевода"""
-    start_time = time.time()
-    
+def validate_translation_quality(original: str, translated: str) -> float:
     try:
-        session = context['task_instance'].xcom_pull(task_ids='initialize_translation')
-        translation_results = context['task_instance'].xcom_pull(task_ids='perform_translation')
-        
-        original_config = session['original_config']
-        target_language = session['target_language']
-        timestamp = original_config.get('timestamp', int(time.time()))
-        filename = original_config.get('filename', 'unknown.pdf')
-        
-        # Определение пути сохранения
-        output_dir = f"/app/output/{target_language}"
-        os.makedirs(output_dir, exist_ok=True)
-        
-        translated_filename = f"{timestamp}_{filename.replace('.pdf', '.md')}"
-        output_path = f"{output_dir}/{translated_filename}"
-        
-        # Сохранение переведенного контента
-        with open(output_path, 'w', encoding='utf-8') as f:
-            f.write(translation_results['translated_content'])
-        
-        # Подготовка конфигурации для Stage 4
-        stage4_config = {
-            'translated_file': output_path,
-            'translated_content': translation_results['translated_content'],
-            'original_config': original_config,
-            'stage3_completed': True,
-            'translation_metadata': {
-                'target_language': target_language,
-                'quality_score': translation_results['quality_score'],
-                'translation_method': 'builtin_dictionary_v3',
-                'chinese_chars_remaining': translation_results['translation_stats']['chinese_chars_remaining'],
-                'technical_terms_preserved': translation_results['translation_stats']['technical_terms_preserved'],
-                'completion_time': datetime.now().isoformat()
-            }
+        if not original.strip():
+            return 100.0
+
+        score = 100.0
+        length_ratio = len(translated) / max(len(original), 1)
+        if length_ratio < 0.55 or length_ratio > 2.2:
+            score -= 15
+
+        original_chinese = count_chinese_characters(original)
+        translated_chinese = count_chinese_characters(translated)
+        if original_chinese > 0:
+            reduction = 1 - (translated_chinese / original_chinese)
+            score += max(0.0, reduction) * 25
+        elif translated_chinese > 0:
+            score -= 25
+
+        structure_delta = abs(translated.count("\n\n") - original.count("\n\n"))
+        score -= min(structure_delta * 2, 10)
+
+        return max(0.0, min(100.0, score))
+    except Exception:
+        return 70.0
+
+
+def initialize_translation(**context) -> Dict[str, Any]:
+    start_time = time.time()
+    try:
+        dag_run_conf = context["dag_run"].conf or {}
+        logger.info(
+            "🌐 Инициализация перевода: %s",
+            json.dumps(dag_run_conf, indent=2, ensure_ascii=False),
+        )
+
+        if dag_run_conf.get("skip_stage3", False):
+            raise AirflowSkipException("Stage 3 skipped by orchestrator (no translation required)")
+
+        markdown_file = dag_run_conf.get("markdown_file")
+        if not markdown_file or not os.path.exists(markdown_file):
+            raise ValueError(f"Markdown файл не найден: {markdown_file}")
+
+        with open(markdown_file, "r", encoding="utf-8") as handle:
+            markdown_content = handle.read()
+
+        if not markdown_content.strip():
+            raise ValueError("Нет контента для перевода")
+
+        original_config = dag_run_conf.get("original_config", {})
+        target_language = original_config.get("target_language", dag_run_conf.get("target_language", "ru"))
+
+        translation_session = {
+            "session_id": f"translation_{int(time.time())}",
+            "markdown_file": markdown_file,
+            "markdown_content": markdown_content,
+            "source_language": dag_run_conf.get("source_language", "zh-CN"),
+            "target_language": target_language,
+            "original_config": original_config,
+            "lines_total": len(markdown_content.split("\n")),
+            "processing_start_time": datetime.now().isoformat(),
         }
-        
+
         MetricsUtils.record_processing_metrics(
-            dag_id='translation_pipeline',
-            task_id='save_translation_result',
+            dag_id="translation_pipeline",
+            task_id="initialize_translation",
             processing_time=time.time() - start_time,
-            success=True
+            success=True,
         )
-        
-        logger.info(f"💾 Перевод сохранен: {output_path}")
-        return stage4_config
-        
-    except Exception as e:
+
+        logger.info(
+            "✅ Перевод инициализирован: %s (%s строк)",
+            target_language,
+            translation_session["lines_total"],
+        )
+        return translation_session
+    except Exception as exc:
         MetricsUtils.record_processing_metrics(
-            dag_id='translation_pipeline',
-            task_id='save_translation_result',
+            dag_id="translation_pipeline",
+            task_id="initialize_translation",
             processing_time=time.time() - start_time,
-            success=False
+            success=False,
         )
-        logger.error(f"❌ Ошибка сохранения перевода: {e}")
+        logger.error("❌ Ошибка инициализации перевода: %s", exc)
         raise
 
-def notify_translation_completion(**context) -> None:
-    """Уведомление о завершении перевода"""
+
+def perform_translation(**context) -> Dict[str, Any]:
+    start_time = time.time()
+    session = context["task_instance"].xcom_pull(task_ids="initialize_translation")
+
+    source_lang = session.get("source_language", "zh-CN")
+    target_language = session.get("target_language", "ru")
+    markdown_content = session["markdown_content"]
+
+    stats: Dict[str, Any] = {
+        "total_chunks": 0,
+        "successful_chunks": 0,
+        "failed_chunks": 0,
+        "api_calls": 0,
+        "successful_requests": 0,
+        "failed_requests": 0,
+        "retries": 0,
+        "latencies": [],
+        "errors": [],
+    }
+
     try:
-        stage4_config = context['task_instance'].xcom_pull(task_ids='save_translation_result')
-        translation_metadata = stage4_config['translation_metadata']
-        
-        target_language = translation_metadata['target_language']
-        quality_score = translation_metadata['quality_score']
-        chinese_remaining = translation_metadata['chinese_chars_remaining']
-        tech_terms = translation_metadata['technical_terms_preserved']
-        
+        batches = build_translation_batches(markdown_content)
+        logger.info("📦 Подготовлено чанков для перевода: %s", len(batches))
+
+        translated_segments: List[str] = []
+        translatable_count = sum(1 for batch in batches if batch["type"] == "translatable")
+
+        chunk_counter = 0
+        for index, batch in enumerate(batches):
+            if batch["type"] == "raw":
+                translated_segments.append(batch["content"])
+                continue
+
+            stats["total_chunks"] += 1
+            translated = call_translator_with_retries(
+                batch["content"],
+                source_lang,
+                target_language,
+                stats,
+                chunk_counter,
+                translatable_count,
+            )
+            chunk_counter += 1
+
+            if translated is None:
+                stats["failed_chunks"] += 1
+                stats["errors"].append({
+                    "chunk_index": index,
+                    "content_preview": batch["content"][:120],
+                })
+                translated_segments.append(batch["content"])
+                continue
+
+            stats["successful_chunks"] += 1
+            translated_segments.append(translated)
+
+        final_content = "\n".join(translated_segments)
+        processing_time = time.time() - start_time
+        chinese_remaining = count_chinese_characters(final_content)
+        quality_score = validate_translation_quality(markdown_content, final_content)
+
+        average_latency = mean(stats["latencies"]) if stats["latencies"] else 0.0
+        max_latency = max(stats["latencies"]) if stats["latencies"] else 0.0
+
+        translation_results = {
+            "translated_content": final_content,
+            "source_length": len(markdown_content),
+            "translated_length": len(final_content),
+            "quality_score": quality_score,
+            "translation_stats": {
+                "processing_time_seconds": processing_time,
+                "translation_method": "translator_microservice_vllm",
+                "chunks_total": stats["total_chunks"],
+                "chunks_successful": stats["successful_chunks"],
+                "chunks_failed": stats["failed_chunks"],
+                "api_calls": stats["api_calls"],
+                "api_success": stats["successful_requests"],
+                "api_failures": stats["failed_requests"],
+                "avg_latency_seconds": round(average_latency, 3),
+                "max_latency_seconds": round(max_latency, 3),
+                "model": TRANSLATION_CONFIG["model"],
+                "service_url": TRANSLATION_CONFIG["service_url"],
+                "chinese_chars_remaining": chinese_remaining,
+                "errors": stats["errors"],
+            },
+        }
+
+        MetricsUtils.record_processing_metrics(
+            dag_id="translation_pipeline",
+            task_id="perform_translation",
+            processing_time=processing_time,
+            success=stats["failed_chunks"] == 0,
+            chunks_total=stats["total_chunks"],
+            api_failures=stats["failed_requests"],
+        )
+
+        logger.info(
+            "✅ Перевод завершен: %s успешных чанков, %s с ошибками",
+            stats["successful_chunks"],
+            stats["failed_chunks"],
+        )
+        return translation_results
+    except Exception as exc:
+        MetricsUtils.record_processing_metrics(
+            dag_id="translation_pipeline",
+            task_id="perform_translation",
+            processing_time=time.time() - start_time,
+            success=False,
+        )
+        logger.error("❌ Ошибка выполнения перевода: %s", exc)
+        raise
+
+
+def save_translation_result(**context) -> Dict[str, Any]:
+    start_time = time.time()
+    try:
+        session = context["task_instance"].xcom_pull(task_ids="initialize_translation")
+        translation_results = context["task_instance"].xcom_pull(task_ids="perform_translation")
+
+        original_config = session.get("original_config", {})
+        target_language = session.get("target_language", "ru")
+        timestamp = original_config.get("timestamp", int(time.time()))
+        filename = original_config.get("filename", "document.pdf")
+
+        output_dir = f"/app/output/{target_language}"
+        os.makedirs(output_dir, exist_ok=True)
+
+        translated_filename = f"{timestamp}_{filename.replace('.pdf', '.md')}"
+        output_path = os.path.join(output_dir, translated_filename)
+
+        with open(output_path, "w", encoding="utf-8") as handle:
+            handle.write(translation_results["translated_content"])
+
+        translation_metadata = {
+            "target_language": target_language,
+            "quality_score": translation_results["quality_score"],
+            "translation_method": translation_results["translation_stats"]["translation_method"],
+            "avg_latency_seconds": translation_results["translation_stats"]["avg_latency_seconds"],
+            "max_latency_seconds": translation_results["translation_stats"]["max_latency_seconds"],
+            "chunks_total": translation_results["translation_stats"]["chunks_total"],
+            "chunks_failed": translation_results["translation_stats"]["chunks_failed"],
+            "model": translation_results["translation_stats"]["model"],
+            "service_url": translation_results["translation_stats"]["service_url"],
+            "chinese_chars_remaining": translation_results["translation_stats"]["chinese_chars_remaining"],
+            "completion_time": datetime.now().isoformat(),
+        }
+
+        stage4_config = {
+            "translated_file": output_path,
+            "translated_content": translation_results["translated_content"],
+            "original_config": original_config,
+            "stage3_completed": True,
+            "translation_metadata": translation_metadata,
+        }
+
+        MetricsUtils.record_processing_metrics(
+            dag_id="translation_pipeline",
+            task_id="save_translation_result",
+            processing_time=time.time() - start_time,
+            success=True,
+        )
+
+        logger.info("💾 Перевод сохранен: %s", output_path)
+        return stage4_config
+    except Exception as exc:
+        MetricsUtils.record_processing_metrics(
+            dag_id="translation_pipeline",
+            task_id="save_translation_result",
+            processing_time=time.time() - start_time,
+            success=False,
+        )
+        logger.error("❌ Ошибка сохранения перевода: %s", exc)
+        raise
+
+
+def notify_translation_completion(**context) -> None:
+    try:
+        stage4_config = context["task_instance"].xcom_pull(task_ids="save_translation_result")
+        translation_metadata = stage4_config["translation_metadata"]
+
         message = f"""
 ✅ TRANSLATION PIPELINE ЗАВЕРШЕН УСПЕШНО
 
-🌐 Целевой язык: {target_language}
-🎯 Качество перевода: {quality_score:.1f}%
-🈶 Китайских символов осталось: {chinese_remaining}
-🔧 Технических терминов сохранено: {tech_terms}
-📊 Метод: {translation_metadata['translation_method']}
+🌐 Целевой язык: {translation_metadata['target_language']}
+🎯 Качество перевода: {translation_metadata['quality_score']:.1f}%
+⏱️ Средняя задержка vLLM: {translation_metadata['avg_latency_seconds']:.2f} с
+📦 Чанков с ошибками: {translation_metadata['chunks_failed']} из {translation_metadata['chunks_total']}
+🤖 Модель: {translation_metadata['model']}
 📁 Файл: {stage4_config['translated_file']}
-
-✅ Готов к передаче на Stage 4 (Quality Assurance)
-        """
-        
+"""
         logger.info(message)
         NotificationUtils.send_success_notification(context, stage4_config)
-        
-    except Exception as e:
-        logger.error(f"❌ Ошибка отправки уведомления: {e}")
+    except Exception as exc:
+        logger.error("❌ Ошибка отправки уведомления: %s", exc)
 
-# ================================================================================
-# ОПРЕДЕЛЕНИЕ ЗАДАЧ
-# ================================================================================
 
-# Задача 1: Инициализация перевода
 init_translation = PythonOperator(
-    task_id='initialize_translation',
+    task_id="initialize_translation",
     python_callable=initialize_translation,
     execution_timeout=timedelta(minutes=5),
-    dag=dag
+    dag=dag,
 )
 
-# Задача 2: Выполнение перевода
 perform_translation_task = PythonOperator(
-    task_id='perform_translation',
+    task_id="perform_translation",
     python_callable=perform_translation,
-    execution_timeout=timedelta(minutes=20),
-    dag=dag
+    execution_timeout=timedelta(minutes=30),
+    dag=dag,
 )
 
-# Задача 3: Сохранение результата
 save_result = PythonOperator(
-    task_id='save_translation_result',
+    task_id="save_translation_result",
     python_callable=save_translation_result,
     execution_timeout=timedelta(minutes=5),
-    dag=dag
+    dag=dag,
 )
 
-# Задача 4: Уведомление о завершении
 notify_completion = PythonOperator(
-    task_id='notify_translation_completion',
+    task_id="notify_translation_completion",
     python_callable=notify_translation_completion,
-    trigger_rule='all_done',
+    trigger_rule="all_done",
     execution_timeout=timedelta(minutes=2),
-    dag=dag
+    dag=dag,
 )
 
-# Определение зависимостей
 init_translation >> perform_translation_task >> save_result >> notify_completion
 
-# Обработка ошибок
-def handle_translation_failure(context):
-    """Обработка ошибок перевода"""
+
+def handle_translation_failure(context: Dict[str, Any]) -> None:
     try:
-        failed_task = context['task_instance'].task_id
-        exception = context.get('exception')
-        
+        failed_task = context["task_instance"].task_id
+        exception = context.get("exception")
         error_message = f"""
 🔥 ОШИБКА В TRANSLATION PIPELINE
 
 Задача: {failed_task}
-Ошибка: {str(exception) if exception else 'Unknown'}
+Ошибка: {exception}
 
-Возможные причины:
-1. Отсутствует Markdown файл от Stage 2
-2. Неподдерживаемый язык перевода
-3. Проблемы с сохранением результата
-4. Ошибки в словарях перевода
-
-Требуется проверка входных данных и конфигурации.
-        """
-        
+Проверьте доступность translator service ({TRANSLATION_CONFIG['service_url']}),
+настройки модели ({TRANSLATION_CONFIG['model']}) и входные данные Stage 2.
+"""
         logger.error(error_message)
         NotificationUtils.send_failure_notification(context, exception)
-        
-    except Exception as e:
-        logger.error(f"❌ Ошибка в обработчике ошибок: {e}")
+    except Exception as exc:
+        logger.error("❌ Ошибка в обработчике ошибок: %s", exc)
 
-# Применение обработчика ошибок ко всем задачам
+
 for task in dag.tasks:
     task.on_failure_callback = handle_translation_failure


### PR DESCRIPTION
## Summary
- replace the hard-coded dictionary translator with calls to the translator microservice configured via environment settings
- add per-chunk batching, retries, and detailed latency/error metrics for vLLM-backed translations
- update notification metadata to surface real service performance instead of pseudo-translation stats

## Testing
- python -m compileall airflow/dags/translation_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68e7d8d6bfc08331ab6b3cb1c91c517c