### PR TITLE
Use python3 entrypoint in service containers

### DIFF
--- a/document_processor/dockerfile.docprocessor
+++ b/document_processor/dockerfile.docprocessor
@@ -90,4 +90,4 @@ EXPOSE 8001 9001
 HEALTHCHECK --interval=30s --timeout=10s --start-period=300s --retries=3 \
     CMD curl -f http://localhost:8001/health || exit 1
 
-CMD ["python", "main.py"]
+CMD ["python3", "main.py"]

--- a/quality_assurance/dockerfile.qa
+++ b/quality_assurance/dockerfile.qa
@@ -96,4 +96,4 @@ HEALTHCHECK --interval=30s --timeout=15s --start-period=60s --retries=3 \
     CMD curl -f http://localhost:8002/health || exit 1
 
 # Запуск приложения
-CMD ["python", "main.py"]
+CMD ["python3", "main.py"]

--- a/translator/dockerfile.translator
+++ b/translator/dockerfile.translator
@@ -51,4 +51,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8003/health || exit 1
 
 # Запуск сервиса
-CMD ["python", "translator.py"]
+CMD ["python3", "translator.py"]


### PR DESCRIPTION
## Summary
- update service Dockerfiles to run their applications with python3 instead of relying on python symlinks
- ensure document processor, translator, and QA containers start even when only python3 is available in the image

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ecd50c6cbc8331a2708d4567cf9752