### PR TITLE
Consolidate vLLM model configuration

### DIFF
--- a/airflow/dags/content_transformation.py
+++ b/airflow/dags/content_transformation.py
@@ -91,7 +91,7 @@ HEADING_PATTERNS: List[str] = [
 VLLM_CONFIG: Dict[str, Any] = {
     # Используем имя сервиса Docker Compose для корректного DNS
     'endpoint': os.getenv('VLLM_SERVER_URL', 'http://vllm-server:8000') + '/v1/chat/completions',
-    'model': os.getenv('VLLM_CONTENT_MODEL', 'Qwen/Qwen3-30B-A3B-Instruct-2507'),
+    'model': os.getenv('VLLM_MODEL', 'Qwen/Qwen3-30B-A3B-Instruct-2507'),
     'timeout': int(os.getenv('VLLM_STANDARD_TIMEOUT', '150')),
     'max_tokens': 2048,
     'temperature': 0.3,

--- a/airflow/dags/translation_pipeline.py
+++ b/airflow/dags/translation_pipeline.py
@@ -59,7 +59,7 @@ TRANSLATION_CONFIG: Dict[str, Any] = {
     "max_retries": int(os.getenv("TRANSLATION_MAX_RETRIES", "3")),
     "retry_delay": float(os.getenv("TRANSLATION_RETRY_DELAY", "5")),
     "max_chars_per_chunk": int(os.getenv("TRANSLATION_MAX_CHARS", "3500")),
-    "model": os.getenv("VLLM_TRANSLATION_MODEL", "Qwen/Qwen3-30B-A3B-Instruct-2507"),
+    "model": os.getenv("VLLM_MODEL", "Qwen/Qwen3-30B-A3B-Instruct-2507"),
 }
 
 BATCH_CONFIG: Dict[str, int] = {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,9 +40,8 @@ x-airflow-common: &airflow-common
 
     # Параметры интеграции vLLM
     VLLM_SERVER_URL: ${VLLM_SERVER_URL}
-    VLLM_CONTENT_MODEL: ${VLLM_CONTENT_MODEL}
+    VLLM_MODEL: ${VLLM_MODEL}
     VLLM_MODEL_NAME: ${VLLM_MODEL_NAME}
-    VLLM_TRANSLATION_MODEL: ${VLLM_TRANSLATION_MODEL}
 
     # Микросервисы Stage 3
     TRANSLATOR_URL: ${TRANSLATOR_URL}
@@ -373,7 +372,7 @@ services:
       
       # vLLM интеграция
       VLLM_SERVER_URL: ${VLLM_SERVER_URL}
-      VLLM_TRANSLATION_MODEL: ${VLLM_TRANSLATION_MODEL}
+      VLLM_MODEL: ${VLLM_MODEL}
       
       # Translation settings
       PRESERVE_TECHNICAL_TERMS: "true"

--- a/env
+++ b/env
@@ -30,11 +30,10 @@ DOCLING_MODEL_PATH=/mnt/storage/models/docling
 # ================================================================================
 VLLM_SERVER_URL=http://vllm-server:8000
 
-VLLM_CONTENT_MODEL=Qwen/Qwen3-30B-A3B-Instruct-2507
-VLLM_TRANSLATION_MODEL=Qwen/Qwen3-30B-A3B-Instruct-2507
+VLLM_MODEL=Qwen/Qwen3-30B-A3B-Instruct-2507
 
 # Для совместимости с docker-compose
-VLLM_MODEL_NAME=${VLLM_CONTENT_MODEL}
+VLLM_MODEL_NAME=${VLLM_MODEL}
 
 # Тайм-ауты (секунды)
 VLLM_STANDARD_TIMEOUT=1800

--- a/translator/config.py
+++ b/translator/config.py
@@ -52,7 +52,7 @@ VLLM_API_URL = os.getenv('VLLM_SERVER_URL', 'http://vllm-server:8000')
 VLLM_API_KEY = os.getenv('VLLM_API_KEY', 'pdf-converter-secure-key-2024')
 
 # ✅ ИСПРАВЛЕНО: Правильная модель для перевода
-TRANSLATION_MODEL = os.getenv('VLLM_TRANSLATION_MODEL', 'Qwen/Qwen3-30B-A3B-Instruct-2507')
+TRANSLATION_MODEL = os.getenv('VLLM_MODEL', 'Qwen/Qwen3-30B-A3B-Instruct-2507')
 
 # ✅ ИСПРАВЛЕНО: OpenAI-совместимый endpoint для vLLM
 API_ENDPOINT = "/v1/chat/completions"

--- a/translator/translator.py
+++ b/translator/translator.py
@@ -158,7 +158,7 @@ logger = configure_logging(
 # vLLM API конфигурация (ИСПРАВЛЕНО)
 VLLM_API_URL = os.getenv('VLLM_SERVER_URL', 'http://vllm-server:8000')
 VLLM_API_ENDPOINT = "/v1/chat/completions"
-TRANSLATION_MODEL = os.getenv('VLLM_TRANSLATION_MODEL', 'Qwen/Qwen3-30B-A3B-Instruct-2507')
+TRANSLATION_MODEL = os.getenv('VLLM_MODEL', 'Qwen/Qwen3-30B-A3B-Instruct-2507')
 
 # API параметры
 API_TEMPERATURE = float(os.getenv('VLLM_TEMPERATURE', '0.1'))


### PR DESCRIPTION
## Summary
- replace separate vLLM content and translation variables with a single `VLLM_MODEL`
- update docker-compose, Airflow DAGs, and translator service to use the unified model name

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ed01957400833190a4ba9002ceb0be