### PR TITLE
Ensure vLLM API key is required

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ x-airflow-common: &airflow-common
     # Параметры интеграции vLLM
     VLLM_SERVER_URL: ${VLLM_SERVER_URL}
     VLLM_MODEL_NAME: ${VLLM_MODEL_NAME}
+    VLLM_API_KEY: ${VLLM_API_KEY}
 
     # Микросервисы Stage 3
     TRANSLATOR_URL: ${TRANSLATOR_URL}
@@ -321,6 +322,7 @@ services:
       
       # Service integration
       VLLM_SERVER_URL: ${VLLM_SERVER_URL}
+      VLLM_API_KEY: ${VLLM_API_KEY}
       DOCUMENT_PROCESSOR_URL: ${DOCUMENT_PROCESSOR_URL}
       
       # Paths
@@ -372,6 +374,7 @@ services:
       # vLLM интеграция
       VLLM_SERVER_URL: ${VLLM_SERVER_URL}
       VLLM_MODEL_NAME: ${VLLM_MODEL_NAME}
+      VLLM_API_KEY: ${VLLM_API_KEY}
       
       # Translation settings
       PRESERVE_TECHNICAL_TERMS: "true"


### PR DESCRIPTION
## Summary
- export the VLLM_API_KEY into the Airflow, quality assurance, and translator service containers
- enforce explicit API key configuration in the shared vLLM client helpers
- update unit tests to cover the new missing-key behavior

## Testing
- pytest tests/test_vllm_client.py

------
https://chatgpt.com/codex/tasks/task_e_68ed37f317808331b829ec5a24dd5fca