### PR TITLE
Configure vLLM API key propagation and health checks

### DIFF
--- a/airflow/dags/shared_utils.py
+++ b/airflow/dags/shared_utils.py
@@ -15,6 +15,9 @@ from datetime import datetime
 from typing import Dict, Any, Optional, List, Union
 from pathlib import Path
 
+from translator import config as translator_config
+from translator.vllm_client import build_vllm_headers
+
 # Настройка логирования
 logger = logging.getLogger(__name__)
 
@@ -367,11 +370,17 @@ class VLLMUtils:
             base = endpoint
             # отбрасываем путь до /v1/...
             if '/v1/' in base:
-                base = base.split('/v1/')
+                base = base.split('/v1/')[0]
+
+            headers = build_vllm_headers(api_key=translator_config.VLLM_API_KEY)
 
             # Попытка /health
             try:
-                resp = requests.get(f"{base}/health", timeout=timeout)
+                resp = requests.get(
+                    f"{base}/health",
+                    timeout=timeout,
+                    headers=headers,
+                )
                 if resp.status_code == 200:
                     return True
             except Exception:
@@ -379,7 +388,11 @@ class VLLMUtils:
 
             # Попытка /v1/models
             try:
-                resp = requests.get(f"{base}/v1/models", timeout=timeout)
+                resp = requests.get(
+                    f"{base}/v1/models",
+                    timeout=timeout,
+                    headers=headers,
+                )
                 return resp.status_code == 200
             except Exception:
                 return False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ x-airflow-common: &airflow-common
     # Параметры интеграции vLLM
     VLLM_SERVER_URL: ${VLLM_SERVER_URL}
     VLLM_MODEL_NAME: ${VLLM_MODEL_NAME}
+    VLLM_API_KEY: ${VLLM_API_KEY}
 
     # Микросервисы Stage 3
     TRANSLATOR_URL: ${TRANSLATOR_URL}
@@ -372,6 +373,7 @@ services:
       # vLLM интеграция
       VLLM_SERVER_URL: ${VLLM_SERVER_URL}
       VLLM_MODEL_NAME: ${VLLM_MODEL_NAME}
+      VLLM_API_KEY: ${VLLM_API_KEY}
       
       # Translation settings
       PRESERVE_TECHNICAL_TERMS: "true"


### PR DESCRIPTION
## Summary
- inject `VLLM_API_KEY` into the translator and Airflow services and thread it through the shared vLLM clients
- update the translator health-check and Airflow utilities to probe `/v1/models` with authentication so 401 errors surface immediately

## Testing
- pytest tests/test_vllm_client.py *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_68ed3cfcfb8483319c4ae837fcfce9f6