### PR TITLE
Align vLLM API key handling across translator and DAG

### DIFF
--- a/airflow/dags/shared_utils.py
+++ b/airflow/dags/shared_utils.py
@@ -109,6 +109,39 @@ class SharedUtils:
 class ConfigUtils:
     """Утилиты для работы с конфигурацией"""
 
+    _SECRET_CACHE: Dict[str, Optional[str]] = {}
+
+    @staticmethod
+    def get_secret(
+        name: str,
+        default: Optional[str] = None,
+        *,
+        refresh: bool = False,
+    ) -> Optional[str]:
+        """Получение чувствительных значений из окружения с кэшированием."""
+
+        if not refresh and name in ConfigUtils._SECRET_CACHE:
+            return ConfigUtils._SECRET_CACHE[name]
+
+        value = os.getenv(name)
+        if value is None:
+            ConfigUtils._SECRET_CACHE[name] = default
+            return default
+
+        stripped = value.strip()
+        if not stripped:
+            ConfigUtils._SECRET_CACHE[name] = default
+            return default
+
+        ConfigUtils._SECRET_CACHE[name] = stripped
+        return stripped
+
+    @staticmethod
+    def get_vllm_api_key(*, refresh: bool = False) -> Optional[str]:
+        """Возвращает API-ключ vLLM из окружения с возможностью обновления."""
+
+        return ConfigUtils.get_secret("VLLM_API_KEY", refresh=refresh)
+
     @staticmethod
     def get_processing_paths() -> Dict[str, str]:
         # По умолчанию используем контейнерные пути, переопределяемые через env

--- a/translator/translator.py
+++ b/translator/translator.py
@@ -45,6 +45,7 @@ import structlog
 
 from translator.vllm_client import (
     create_vllm_aiohttp_session,
+    get_vllm_api_key,
     get_vllm_server_url,
 )
 
@@ -484,12 +485,18 @@ class VLLMAPIClient:
 
     async def _ensure_http_client(self) -> aiohttp.ClientSession:
         if self._http_client is None or self._http_client.closed:
-            self._http_client = create_vllm_aiohttp_session(timeout=self._client_timeout)
+            self._http_client = create_vllm_aiohttp_session(
+                timeout=self._client_timeout,
+                api_key=get_vllm_api_key(),
+            )
         return self._http_client
 
     async def _refresh_http_client(self) -> aiohttp.ClientSession:
         await self._close_http_client()
-        self._http_client = create_vllm_aiohttp_session(timeout=self._client_timeout)
+        self._http_client = create_vllm_aiohttp_session(
+            timeout=self._client_timeout,
+            api_key=get_vllm_api_key(),
+        )
         return self._http_client
 
     async def enhanced_api_request(self, messages: List[Dict], timeout: int = REQUEST_TIMEOUT) -> Optional[str]:


### PR DESCRIPTION
## Summary
- ensure the translator service always builds aiohttp sessions with the active vLLM API key
- cache vLLM API credentials via ConfigUtils and reuse them when constructing Airflow DAG sessions and headers
- log and abort immediately on 401 responses so unauthorized runs surface as task failures

## Testing
- pytest tests/test_vllm_client.py *(fails: missing requests dependency in environment)*
- docker compose up translator *(fails: docker is not available in the execution environment)*
- airflow dags test content_transformation 2024-08-01 *(fails: airflow is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed433bbbc88331a0e2dc3ed858176a