### PR TITLE
Bundle translator package into the Airflow image

### DIFF
--- a/airflow/dags/content_transformation.py
+++ b/airflow/dags/content_transformation.py
@@ -26,11 +26,6 @@ import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Dict, Any, List, Optional, Tuple
 from requests.adapters import HTTPAdapter
-import sys
-
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.append(str(PROJECT_ROOT))
 
 from translator.vllm_client import (
     build_vllm_headers,

--- a/airflow/dockerfile.airflow
+++ b/airflow/dockerfile.airflow
@@ -47,6 +47,12 @@ COPY airflow/requirements-airflow.txt /requirements-airflow.txt
 RUN pip install --no-cache-dir --upgrade "pip<25" \
     && pip install --no-cache-dir -r /requirements-airflow.txt
 
+# Копирование вспомогательных Python-пакетов, необходимых для DAG'ов
+COPY --chown=airflow:airflow translator/ /opt/airflow/translator/
+
+# Airflow уже добавляет ``/opt/airflow/dags`` в PYTHONPATH, расширим путь для translator
+ENV PYTHONPATH="/opt/airflow:/opt/airflow/dags:${PYTHONPATH}"
+
 # Копирование DAG'ов и плагинов в стандартные каталоги Airflow
 COPY --chown=airflow:airflow airflow/dags/ /opt/airflow/dags/
 

--- a/tests/test_content_transformation_import.py
+++ b/tests/test_content_transformation_import.py
@@ -1,0 +1,164 @@
+"""Tests ensuring the Airflow content_transformation DAG loads in this environment."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Dict, Optional
+
+
+class _FakeDAG:
+    """Minimal stub for :mod:`airflow.DAG` used only for import validation."""
+
+    def __init__(self, *args, **kwargs):  # pragma: no cover - trivial
+        self.args = args
+        self.kwargs = kwargs
+
+    def __enter__(self):  # pragma: no cover - context manager compatibility
+        return self
+
+    def __exit__(self, exc_type, exc, tb):  # pragma: no cover
+        return False
+
+
+class _FakePythonOperator:
+    """Stub implementation matching the API required during module import."""
+
+    def __init__(self, *args, **kwargs):  # pragma: no cover - trivial
+        self.args = args
+        self.kwargs = kwargs
+
+    def __rshift__(self, other):  # pragma: no cover - task chaining support
+        return other
+
+    def __rrshift__(self, other):  # pragma: no cover
+        return self
+
+
+class _FakeRequestsSession:
+    """Simplified ``requests.Session`` replacement used for import-time wiring."""
+
+    def __init__(self, *args, **kwargs):  # pragma: no cover - trivial
+        self.headers: Dict[str, str] = {}
+
+    def mount(self, *args, **kwargs):  # pragma: no cover - no-op
+        return None
+
+    def post(self, *args, **kwargs):  # pragma: no cover - runtime usage is not exercised
+        raise RuntimeError("HTTP requests are not supported in this test stub")
+
+    def close(self):  # pragma: no cover - no-op
+        return None
+
+
+class _FakeHTTPAdapter:  # pragma: no cover - trivial stub
+    def __init__(self, *args, **kwargs):
+        return None
+
+
+def _install_airflow_stubs() -> Dict[str, Optional[ModuleType]]:
+    """Install lightweight Airflow stubs required for DAG import."""
+
+    original_modules: Dict[str, Optional[ModuleType]] = {}
+    for name in (
+        "airflow",
+        "airflow.operators",
+        "airflow.operators.python",
+        "airflow.dags",
+        "requests",
+        "requests.adapters",
+        "shared_utils",
+    ):
+        original_modules[name] = sys.modules.get(name)
+
+    repo_root = Path(__file__).resolve().parents[1]
+    airflow_path = repo_root / "airflow"
+    dags_path = airflow_path / "dags"
+
+    airflow_module = ModuleType("airflow")
+    airflow_module.DAG = _FakeDAG  # type: ignore[attr-defined]
+    airflow_module.__path__ = [str(airflow_path)]  # type: ignore[attr-defined]
+
+    operators_module = ModuleType("airflow.operators")
+    python_module = ModuleType("airflow.operators.python")
+    python_module.PythonOperator = _FakePythonOperator  # type: ignore[attr-defined]
+    operators_module.__path__ = []  # type: ignore[attr-defined]
+    python_module.__path__ = []  # type: ignore[attr-defined]
+
+    dags_module = ModuleType("airflow.dags")
+    dags_module.__path__ = [str(dags_path)]  # type: ignore[attr-defined]
+
+    operators_module.python = python_module  # type: ignore[attr-defined]
+    airflow_module.operators = operators_module  # type: ignore[attr-defined]
+
+    requests_module = ModuleType("requests")
+    requests_module.Session = _FakeRequestsSession  # type: ignore[attr-defined]
+    adapters_module = ModuleType("requests.adapters")
+    adapters_module.HTTPAdapter = _FakeHTTPAdapter  # type: ignore[attr-defined]
+    requests_module.adapters = adapters_module  # type: ignore[attr-defined]
+
+    sys.modules["airflow"] = airflow_module
+    sys.modules["airflow.operators"] = operators_module
+    sys.modules["airflow.operators.python"] = python_module
+    sys.modules["airflow.dags"] = dags_module
+    sys.modules["requests"] = requests_module
+    sys.modules["requests.adapters"] = adapters_module
+
+    shared_utils_spec = importlib.util.spec_from_file_location(
+        "shared_utils", str(dags_path / "shared_utils.py")
+    )
+    if shared_utils_spec and shared_utils_spec.loader:
+        shared_utils_module = importlib.util.module_from_spec(shared_utils_spec)
+        shared_utils_spec.loader.exec_module(shared_utils_module)
+        sys.modules["shared_utils"] = shared_utils_module
+
+    return original_modules
+
+
+def _restore_modules(original_modules: Dict[str, Optional[ModuleType]]) -> None:
+    """Restore any previously loaded modules after import completes."""
+
+    for name, module in original_modules.items():
+        if module is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = module
+
+
+def _import_content_transformation() -> ModuleType:
+    """Import the DAG module using Airflow stubs."""
+
+    original_modules = _install_airflow_stubs()
+    try:
+        dag_module = importlib.import_module("airflow.dags.content_transformation")
+        assert hasattr(dag_module, "dag"), "DAG module should expose a dag instance"
+        return dag_module
+    finally:
+        _restore_modules(original_modules)
+
+
+def _reset_import_state() -> None:
+    sys.modules.pop("airflow.dags.content_transformation", None)
+    sys.modules.pop("translator", None)
+    sys.modules.pop("translator.vllm_client", None)
+
+
+def test_content_transformation_module_imports_with_translator_available():
+    repo_root = Path(__file__).resolve().parents[1]
+    repo_str = str(repo_root)
+
+    if repo_str not in sys.path:
+        sys.path.insert(0, repo_str)
+
+    _reset_import_state()
+    try:
+        dag_module = _import_content_transformation()
+        assert "translator.vllm_client" in sys.modules, "translator package must be importable"
+        assert (
+            dag_module.create_vllm_requests_session.__module__ == "translator.vllm_client"
+        )
+    finally:
+        _reset_import_state()

--- a/translator/__init__.py
+++ b/translator/__init__.py
@@ -1,0 +1,35 @@
+"""Translator package initialization and lightweight public API helpers."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+from .vllm_client import (
+    build_vllm_headers,
+    create_vllm_requests_session,
+    get_vllm_api_key,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - used only for type checkers
+    from .translator import Translator  # noqa: F401
+
+__all__ = [
+    "Translator",
+    "build_vllm_headers",
+    "create_vllm_requests_session",
+    "get_vllm_api_key",
+]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily load heavy submodules on demand.
+
+    This avoids importing optional FastAPI dependencies when only the
+    ``translator.vllm_client`` helpers are required (e.g. in Airflow DAGs).
+    """
+
+    if name == "Translator":
+        module = import_module(".translator", __name__)
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary
- require the real translator client in the content_transformation DAG instead of providing in-file fallbacks
- bake the translator package into the Airflow image and expose it on PYTHONPATH so the DAG import succeeds in WebUI
- refresh the DAG import test to exercise the real translator helpers while keeping lightweight Airflow stubs

## Testing
- pytest tests -k content_transformation
- pytest tests -k auto_corrector


------
https://chatgpt.com/codex/tasks/task_e_68ee4539532c83319f5d646db287bb0a