### PR TITLE
Fix translator package availability in service containers

### DIFF
--- a/airflow/dags/content_transformation.py
+++ b/airflow/dags/content_transformation.py
@@ -27,16 +27,55 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Dict, Any, List, Optional, Tuple
 from requests.adapters import HTTPAdapter
 import sys
+import importlib.util
 
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.append(str(PROJECT_ROOT))
 
-from translator.vllm_client import (
+def _ensure_translator_importable() -> Path:
+    """Make sure the ``translator`` package can be imported.
+
+    Airflow mounts only the ``dags`` directory by default, therefore the
+    supporting ``translator`` package must either be baked into the image or
+    explicitly mounted and its parent directory placed on ``PYTHONPATH``.
+    """
+
+    existing_spec = importlib.util.find_spec("translator")
+    if existing_spec and existing_spec.submodule_search_locations:
+        return Path(existing_spec.submodule_search_locations[0]).parent
+
+    search_roots = []
+    env_path = os.getenv("TRANSLATOR_PACKAGE_PATH")
+    if env_path:
+        search_roots.append(Path(env_path).expanduser().resolve())
+
+    dag_file = Path(__file__).resolve()
+    search_roots.extend(parent for parent in dag_file.parents)
+    search_roots.append(Path.cwd().resolve())
+
+    for root in search_roots:
+        translator_dir = root / "translator"
+        if translator_dir.is_dir():
+            root_str = str(root)
+            if root_str not in sys.path:
+                sys.path.insert(0, root_str)
+            return root
+
+    raise ModuleNotFoundError(
+        "translator package could not be located. "
+        "Ensure the project directory containing the translator module is "
+        "mounted into the Airflow image or provide its location via "
+        "TRANSLATOR_PACKAGE_PATH."
+    )
+
+
+TRANSLATOR_PACKAGE_ROOT = _ensure_translator_importable()
+
+from translator.vllm_client import (  # noqa: E402 - imported after sys.path adjustment
     build_vllm_headers,
     create_vllm_requests_session,
     get_vllm_api_key as get_vllm_env_api_key,
 )
+
+TRANSLATOR_CLIENT_AVAILABLE = True
 
 # ✅ logger до любых try/except
 logger = logging.getLogger(__name__)

--- a/airflow/dockerfile.airflow
+++ b/airflow/dockerfile.airflow
@@ -47,8 +47,12 @@ COPY airflow/requirements-airflow.txt /requirements-airflow.txt
 RUN pip install --no-cache-dir --upgrade "pip<25" \
     && pip install --no-cache-dir -r /requirements-airflow.txt
 
-# Копирование DAG'ов и плагинов в стандартные каталоги Airflow
+# Копирование служебных модулей и DAG'ов в стандартные каталоги Airflow
+COPY --chown=airflow:airflow translator/ /opt/airflow/translator/
 COPY --chown=airflow:airflow airflow/dags/ /opt/airflow/dags/
+
+# Гарантируем доступность translator пакета по умолчанию
+ENV PYTHONPATH="/opt/airflow:${PYTHONPATH}"
 
 
 # Создание рабочих директорий

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,7 @@ x-airflow-common: &airflow-common
     - ${PROJ_DIR}/logs:/opt/airflow/logs
     - ${PROJ_DIR}/airflow/config:/opt/airflow/config
     - ${PROJ_DIR}/airflow/plugins:/opt/airflow/plugins
+    - ${PROJ_DIR}/translator:/opt/airflow/translator:ro
     
 
 
@@ -301,8 +302,8 @@ services:
   # Quality Assurance Service
   quality-assurance:
     build:
-      context: ./quality_assurance
-      dockerfile: dockerfile.qa
+      context: .
+      dockerfile: quality_assurance/dockerfile.qa
     container_name: quality-assurance
     environment:
       # Service configuration
@@ -362,8 +363,8 @@ services:
   # Translator Service
   translator:
     build:
-      context: ./translator
-      dockerfile: dockerfile.translator
+      context: .
+      dockerfile: translator/dockerfile.translator
     container_name: translator
     environment:
       SERVICE_HOST: "0.0.0.0"

--- a/quality_assurance/dockerfile.qa
+++ b/quality_assurance/dockerfile.qa
@@ -59,7 +59,7 @@ RUN useradd --create-home --shell /bin/bash qa
 WORKDIR /app
 
 # Копируем requirements и устанавливаем Python зависимости
-COPY requirements-qa.txt /app/
+COPY quality_assurance/requirements-qa.txt /app/requirements-qa.txt
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel
 RUN pip install --no-cache-dir -r requirements-qa.txt
 
@@ -74,13 +74,17 @@ RUN mkdir -p /app/temp \
     && chown -R qa:qa /mnt/storage/models
 
 # Копируем исходный код приложения
-COPY ocr_validator.py /app/
-COPY visual_diff_system.py /app/
-COPY ast_comparator.py /app/
-COPY ssim_calculator.py /app/
-COPY auto_corrector.py /app/
-COPY content_validator.py /app/
-COPY main.py /app/
+COPY quality_assurance/ocr_validator.py /app/
+COPY quality_assurance/visual_diff_system.py /app/
+COPY quality_assurance/ast_comparator.py /app/
+COPY quality_assurance/ssim_calculator.py /app/
+COPY quality_assurance/auto_corrector.py /app/
+COPY quality_assurance/content_validator.py /app/
+COPY quality_assurance/main.py /app/
+
+# Делаем модуль translator доступным для авто-корректора
+COPY translator /app/translator
+RUN chown -R qa:qa /app/translator
 
 # Устанавливаем права доступа
 RUN chmod +x /app/*.py

--- a/tests/test_content_transformation_import.py
+++ b/tests/test_content_transformation_import.py
@@ -1,0 +1,193 @@
+"""Tests ensuring the Airflow content_transformation DAG loads in this environment."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Dict, Optional
+
+import pytest
+
+
+class _FakeDAG:
+    """Minimal stub for :mod:`airflow.DAG` used only for import validation."""
+
+    def __init__(self, *args, **kwargs):  # pragma: no cover - trivial
+        self.args = args
+        self.kwargs = kwargs
+
+    def __enter__(self):  # pragma: no cover - context manager compatibility
+        return self
+
+    def __exit__(self, exc_type, exc, tb):  # pragma: no cover
+        return False
+
+
+class _FakePythonOperator:
+    """Stub implementation matching the API required during module import."""
+
+    def __init__(self, *args, **kwargs):  # pragma: no cover - trivial
+        self.args = args
+        self.kwargs = kwargs
+
+    def __rshift__(self, other):  # pragma: no cover - task chaining support
+        return other
+
+    def __rrshift__(self, other):  # pragma: no cover
+        return self
+
+
+class _FakeRequestsSession:
+    """Simplified ``requests.Session`` replacement used for import-time wiring."""
+
+    def __init__(self, *args, **kwargs):  # pragma: no cover - trivial
+        self.headers: Dict[str, str] = {}
+
+    def mount(self, *args, **kwargs):  # pragma: no cover - no-op
+        return None
+
+    def close(self):  # pragma: no cover - no-op
+        return None
+
+
+class _FakeHTTPAdapter:  # pragma: no cover - trivial stub
+    def __init__(self, *args, **kwargs):
+        return None
+
+
+def _install_airflow_stubs() -> Dict[str, Optional[ModuleType]]:
+    """Install lightweight Airflow stubs required for DAG import."""
+
+    original_modules: Dict[str, Optional[ModuleType]] = {}
+    for name in (
+        "airflow",
+        "airflow.operators",
+        "airflow.operators.python",
+        "airflow.dags",
+        "requests",
+        "requests.adapters",
+        "shared_utils",
+    ):
+        original_modules[name] = sys.modules.get(name)
+
+    repo_root = Path(__file__).resolve().parents[1]
+    airflow_path = repo_root / "airflow"
+    dags_path = airflow_path / "dags"
+
+    airflow_module = ModuleType("airflow")
+    airflow_module.DAG = _FakeDAG  # type: ignore[attr-defined]
+    airflow_module.__path__ = [str(airflow_path)]  # type: ignore[attr-defined]
+
+    operators_module = ModuleType("airflow.operators")
+    python_module = ModuleType("airflow.operators.python")
+    python_module.PythonOperator = _FakePythonOperator  # type: ignore[attr-defined]
+    operators_module.__path__ = []  # type: ignore[attr-defined]
+    python_module.__path__ = []  # type: ignore[attr-defined]
+
+    dags_module = ModuleType("airflow.dags")
+    dags_module.__path__ = [str(dags_path)]  # type: ignore[attr-defined]
+
+    operators_module.python = python_module  # type: ignore[attr-defined]
+    airflow_module.operators = operators_module  # type: ignore[attr-defined]
+
+    requests_module = ModuleType("requests")
+    requests_module.Session = _FakeRequestsSession  # type: ignore[attr-defined]
+    adapters_module = ModuleType("requests.adapters")
+    adapters_module.HTTPAdapter = _FakeHTTPAdapter  # type: ignore[attr-defined]
+    requests_module.adapters = adapters_module  # type: ignore[attr-defined]
+
+    sys.modules["airflow"] = airflow_module
+    sys.modules["airflow.operators"] = operators_module
+    sys.modules["airflow.operators.python"] = python_module
+    sys.modules["airflow.dags"] = dags_module
+    sys.modules["requests"] = requests_module
+    sys.modules["requests.adapters"] = adapters_module
+
+    shared_utils_spec = importlib.util.spec_from_file_location(
+        "shared_utils", str(dags_path / "shared_utils.py")
+    )
+    if shared_utils_spec and shared_utils_spec.loader:
+        shared_utils_module = importlib.util.module_from_spec(shared_utils_spec)
+        shared_utils_spec.loader.exec_module(shared_utils_module)
+        sys.modules["shared_utils"] = shared_utils_module
+
+    return original_modules
+
+
+def _restore_modules(original_modules: Dict[str, Optional[ModuleType]]) -> None:
+    """Restore any previously loaded modules after import completes."""
+
+    for name, module in original_modules.items():
+        if module is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = module
+
+
+def _import_content_transformation() -> ModuleType:
+    """Import the DAG module using Airflow stubs."""
+
+    original_modules = _install_airflow_stubs()
+    try:
+        dag_module = importlib.import_module("airflow.dags.content_transformation")
+        assert hasattr(dag_module, "dag"), "DAG module should expose a dag instance"
+        return dag_module
+    finally:
+        _restore_modules(original_modules)
+
+
+def _reset_import_state() -> None:
+    sys.modules.pop("airflow.dags.content_transformation", None)
+    sys.modules.pop("translator", None)
+    sys.modules.pop("translator.vllm_client", None)
+
+
+def test_content_transformation_module_imports_with_translator_available():
+    repo_root = Path(__file__).resolve().parents[1]
+    repo_str = str(repo_root)
+
+    # Simulate an Airflow environment where the repository root is not already
+    # present on ``sys.path``. The DAG should restore this as part of its
+    # import-time setup.
+    removed_path = False
+    if repo_str in sys.path:
+        sys.path.remove(repo_str)
+        removed_path = True
+
+    try:
+        _reset_import_state()
+        dag_module = _import_content_transformation()
+        assert dag_module.TRANSLATOR_CLIENT_AVAILABLE is True
+        assert hasattr(dag_module, "TRANSLATOR_PACKAGE_ROOT")
+        assert Path(dag_module.TRANSLATOR_PACKAGE_ROOT).resolve() == repo_root
+        assert "translator.vllm_client" in sys.modules, "translator package must be importable"
+    finally:
+        _reset_import_state()
+        if removed_path:
+            sys.path.insert(0, repo_str)
+
+
+def test_content_transformation_import_fails_when_translator_missing():
+    repo_root = Path(__file__).resolve().parents[1]
+    translator_dir = repo_root / "translator"
+    backup_dir = repo_root / "_translator_backup"
+
+    if backup_dir.exists():  # pragma: no cover - defensive cleanup
+        if backup_dir.is_dir():
+            for child in backup_dir.iterdir():
+                raise AssertionError("Unexpected leftover backup directory contents")
+        backup_dir.unlink()
+
+    translator_dir.rename(backup_dir)
+
+    try:
+        _reset_import_state()
+        with pytest.raises(ModuleNotFoundError) as excinfo:
+            _import_content_transformation()
+        assert "translator package could not be located" in str(excinfo.value)
+    finally:
+        _reset_import_state()
+        backup_dir.rename(translator_dir)

--- a/translator/__init__.py
+++ b/translator/__init__.py
@@ -1,0 +1,35 @@
+"""Translator package initialization and lightweight public API helpers."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+from .vllm_client import (
+    build_vllm_headers,
+    create_vllm_requests_session,
+    get_vllm_api_key,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - used only for type checkers
+    from .translator import Translator  # noqa: F401
+
+__all__ = [
+    "Translator",
+    "build_vllm_headers",
+    "create_vllm_requests_session",
+    "get_vllm_api_key",
+]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily load heavy submodules on demand.
+
+    This avoids importing optional FastAPI dependencies when only the
+    ``translator.vllm_client`` helpers are required (e.g. in Airflow DAGs).
+    """
+
+    if name == "Translator":
+        module = import_module(".translator", __name__)
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/translator/dockerfile.translator
+++ b/translator/dockerfile.translator
@@ -21,15 +21,14 @@ RUN groupadd -r translator && useradd -r -g translator translator
 WORKDIR /app
 
 # Копирование requirements
-COPY requirements-translator.txt .
+COPY translator/requirements-translator.txt ./requirements-translator.txt
 
 # Установка Python зависимостей
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements-translator.txt
 
-# Копирование исходного кода
-COPY translator.py .
-COPY config.py .
+# Копирование исходного кода (как полноценного Python-пакета)
+COPY translator /app/translator
 
 # Создание необходимых директорий
 RUN mkdir -p /app/temp /app/logs /app/cache && \
@@ -50,5 +49,5 @@ EXPOSE 8003
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8003/health || exit 1
 
-# Запуск сервиса
-CMD ["python", "translator.py"]
+# Запуск сервиса как модуля, чтобы использовать пакет translator
+CMD ["python", "-m", "translator.translator"]


### PR DESCRIPTION
## Summary
- build both translator and QA images from the repository root so they can bundle the local translator package
- copy the translator package into the translator and QA images, running the translator service as a module to avoid import errors
- ensure the QA image retains ownership of the bundled translator code for runtime access

## Testing
- pytest tests -k content_transformation
- pytest tests -k auto_corrector

------
https://chatgpt.com/codex/tasks/task_e_68ee4539532c83319f5d646db287bb0a