### PR TITLE
Fix markdown path handling for Stage 2 results

### DIFF
--- a/airflow/dags/orchestrator_dag.py
+++ b/airflow/dags/orchestrator_dag.py
@@ -234,7 +234,7 @@ def check_stage2_completion(**context) -> Dict[str, Any]:
         for path in [expected_md_file, host_md_file, fallback_md_file]:
             if os.path.exists(path):
                 md_file_path = path
-                logger.info(f"✅ Найден MD файл: {path}")
+                logger.info(f"✅ Найден MD файл по точному пути: {path}")
                 break
         if not md_file_path:
             patterns = [
@@ -246,10 +246,15 @@ def check_stage2_completion(**context) -> Dict[str, Any]:
                 f"/opt/airflow/output/zh/{filename.replace('.pdf', '.md')}",
             ]
             for pattern in patterns:
-                files = glob.glob(pattern)
+                files = sorted(glob.glob(pattern))
                 if files:
-                    md_file_path = files
+                    md_file_path = files[0]
+                    logger.info(
+                        "✅ Найден MD файл по шаблону %s: %s", pattern, md_file_path
+                    )
                     break
+        if isinstance(md_file_path, list):
+            md_file_path = sorted(md_file_path)[0]
         if not md_file_path:
             raise AirflowException(f"❌ MD файл для {filename} не найден")
         stage2_completion = {
@@ -259,7 +264,7 @@ def check_stage2_completion(**context) -> Dict[str, Any]:
             'original_config': master_config,
             'completion_time': datetime.now().isoformat(),
         }
-        logger.info(f"✅ Stage 2 завершен успешно: {md_file_path}")
+        logger.info(f"✅ Stage 2 завершен успешно, выбран файл: {md_file_path}")
         return stage2_completion
     except Exception as e:
         logger.error(f"❌ Ошибка проверки Stage 2: {e}")
@@ -272,8 +277,17 @@ def prepare_stage3_config(**context) -> Dict[str, Any]:
         if not master_config['translation_required']:
             logger.info("🔄 Перевод не требуется, пропускаем Stage 3")
             return {'skip_stage3': True}
+        markdown_file = stage2_result['markdown_file']
+        if isinstance(markdown_file, list):
+            markdown_file = sorted(markdown_file)[0]
+            logger.warning("⚠️ Получен список путей MD, выбран первый: %s", markdown_file)
+        if not isinstance(markdown_file, str):
+            raise AirflowException(f"Некорректный тип пути MD файла: {type(markdown_file)}")
+        if not os.path.exists(markdown_file):
+            raise AirflowException(f"Markdown файл не найден перед Stage 3: {markdown_file}")
+
         stage3_config = {
-            'markdown_file': stage2_result['markdown_file'],
+            'markdown_file': markdown_file,
             'original_config': master_config,
             'stage2_completed': True,
             'target_language': master_config['target_language'],


### PR DESCRIPTION
## Summary
- ensure Stage 2 resolution of markdown files stores a concrete path and logs the final selection
- validate Stage 3 configuration receives a string markdown path and confirm the file exists before continuing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ef790b0034833183f168f876f1a3ca