### PR TITLE
Fix metrics endpoint content type

### DIFF
--- a/translator/translator.py
+++ b/translator/translator.py
@@ -29,7 +29,7 @@ from typing import List, Dict, Tuple, Optional
 from dataclasses import dataclass, field
 
 # FastAPI и веб-сервер
-from fastapi import FastAPI, HTTPException, BackgroundTasks
+from fastapi import FastAPI, HTTPException, BackgroundTasks, Response
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 import uvicorn
@@ -998,7 +998,10 @@ async def get_translation_stats():
 @app.get("/metrics")
 async def metrics():
     """Prometheus метрики"""
-    return prometheus_client.generate_latest()
+    return Response(
+        prometheus_client.generate_latest(),
+        media_type=prometheus_client.CONTENT_TYPE_LATEST,
+    )
 
 # ==============================================
 # 💎 ЗАПУСК СЕРВЕРА


### PR DESCRIPTION
## Summary
- import `Response` from FastAPI for the translator service
- wrap Prometheus metrics output in a `Response` with the correct content type to avoid JSON encoding

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ef7ddf815883318c4cfff69dd1b0d9