### PR TITLE
Propagate vLLM API key to translator clients

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ x-airflow-common: &airflow-common
     # Параметры интеграции vLLM
     VLLM_SERVER_URL: ${VLLM_SERVER_URL}
     VLLM_MODEL_NAME: ${VLLM_MODEL_NAME}
+    VLLM_API_KEY: ${VLLM_API_KEY}
 
     # Микросервисы Stage 3
     TRANSLATOR_URL: ${TRANSLATOR_URL}
@@ -322,6 +323,7 @@ services:
       
       # Service integration
       VLLM_SERVER_URL: ${VLLM_SERVER_URL}
+      VLLM_API_KEY: ${VLLM_API_KEY}
       DOCUMENT_PROCESSOR_URL: ${DOCUMENT_PROCESSOR_URL}
       
       # Paths
@@ -373,6 +375,7 @@ services:
       # vLLM интеграция
       VLLM_SERVER_URL: ${VLLM_SERVER_URL}
       VLLM_MODEL_NAME: ${VLLM_MODEL_NAME}
+      VLLM_API_KEY: ${VLLM_API_KEY}
       
       # Translation settings
       PRESERVE_TECHNICAL_TERMS: "true"


### PR DESCRIPTION
## Summary
- expose the VLLM_API_KEY environment variable to all vLLM clients in docker-compose

## Testing
- not run (container lacks Docker daemon)

------
https://chatgpt.com/codex/tasks/task_e_68efa2c9e49c8331a42045002c53e1f2