### PR TITLE
Track failed translation API calls

### DIFF
--- a/translator/__init__.py
+++ b/translator/__init__.py
@@ -5,11 +5,24 @@ from __future__ import annotations
 from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
-from .vllm_client import (
-    build_vllm_headers,
-    create_vllm_requests_session,
-    get_vllm_api_key,
-)
+try:
+    from .vllm_client import (
+        build_vllm_headers,
+        create_vllm_requests_session,
+        get_vllm_api_key,
+    )
+except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency guard
+    if exc.name != "requests":
+        raise
+
+    def _missing_requests(*_args, **_kwargs):
+        raise ModuleNotFoundError(
+            "translator optional dependency 'requests' is required for HTTP helpers"
+        ) from exc
+
+    build_vllm_headers = _missing_requests
+    create_vllm_requests_session = _missing_requests
+    get_vllm_api_key = _missing_requests
 
 if TYPE_CHECKING:  # pragma: no cover - used only for type checkers
     from .translator import Translator  # noqa: F401


### PR DESCRIPTION
## Summary
- count translation API attempts immediately after each vLLM request
- expose a Prometheus counter and stats field for failed API calls
- harden translator package init against missing optional dependencies and extend unit tests for failure paths

## Testing
- pytest translator/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68efd0a7995483319e80de9878f30f64