### PR TITLE
Fix QA finalize pipeline readiness flag

### DIFF
--- a/airflow/dags/quality_assurance.py
+++ b/airflow/dags/quality_assurance.py
@@ -2116,8 +2116,12 @@ def finalize_qa_process(**context) -> Dict[str, Any]:
         auto_correction_summary = comprehensive_report['level_results']['level5_auto_correction']
         auto_correction_status = auto_correction_summary.get('status')
         auto_correction_followup = auto_correction_summary.get('requires_manual_followup', False)
+
+        qa_completed = auto_correction_status == 'completed' and not auto_correction_followup
+        pipeline_ready = comprehensive_report['quality_passed'] and qa_completed
+
         final_result = {
-            'qa_completed': auto_correction_status == 'completed' and not auto_correction_followup,
+            'qa_completed': qa_completed,
             'enterprise_validation': True,
             'quality_score': comprehensive_report['overall_score'],
             'quality_passed': comprehensive_report['quality_passed'],
@@ -2126,7 +2130,7 @@ def finalize_qa_process(**context) -> Dict[str, Any]:
             'qa_report': comprehensive_report['report_file'],
             'issues_count': len(comprehensive_report['all_issues']),
             'corrections_applied': comprehensive_report.get('corrections_applied', 0),
-            'pipeline_ready': comprehensive_report['quality_passed'] and final_result['qa_completed'],
+            'pipeline_ready': pipeline_ready,
             '5_level_validation_complete': True,
             'level_scores': comprehensive_report['level_scores'],
             'pdf_comparison_performed': True,

--- a/airflow/tests/test_quality_assurance_auto_correction.py
+++ b/airflow/tests/test_quality_assurance_auto_correction.py
@@ -343,3 +343,52 @@ def test_auto_correction_success_allows_translation(monkeypatch, tmp_path, caplo
     assert stage3_config['qa_gate_passed'] is True
     assert stage3_config['qa_summary']['qa_gate_passed'] is True
     assert "Перевод заблокирован" not in caplog.text
+
+
+def test_finalize_qa_process_marks_pipeline_ready(tmp_path):
+    qa_report_path = tmp_path / "qa_report.json"
+    qa_report_path.write_text("{}", encoding="utf-8")
+
+    translated_file = tmp_path / "translated.md"
+    translated_text = "Corrected content"
+    translated_file.write_text(translated_text, encoding="utf-8")
+
+    qa_session = {
+        'translated_content': translated_text,
+        'translated_file': str(translated_file),
+    }
+
+    comprehensive_report = {
+        'overall_score': 98.5,
+        'quality_passed': True,
+        'report_file': str(qa_report_path),
+        'all_issues': [],
+        'corrections_applied': 2,
+        'corrected_content': "Final, production-ready content.",
+        'level_scores': {
+            'level1_integrity': 1.0,
+            'level2_formatting': 0.95,
+            'level3_semantics': 0.98,
+            'level4_visual': 1.0,
+            'level5_auto_correction': 1.0,
+        },
+        'level_results': {
+            'level5_auto_correction': {
+                'status': 'completed',
+                'requires_manual_followup': False,
+                'partial_success': False,
+            }
+        },
+    }
+
+    context = {'load_translated_document': qa_session,
+               'generate_comprehensive_qa_report': comprehensive_report}
+
+    result = quality_assurance.finalize_qa_process(
+        task_instance=DummyTaskInstance(context)
+    )
+
+    assert result['qa_completed'] is True
+    assert result['pipeline_ready'] is True
+    assert result['auto_correction_status'] == 'completed'
+    assert result['auto_correction_requires_manual_followup'] is False


### PR DESCRIPTION
## Summary
- compute qa completion and pipeline readiness flags before constructing the final QA payload
- populate the final result mapping from the derived locals instead of referencing partially built data
- add a regression test covering a fully successful QA flow and asserting the payload reports pipeline readiness

## Testing
- pytest airflow/tests/test_quality_assurance_auto_correction.py

------
https://chatgpt.com/codex/tasks/task_e_68f0dbf058dc8331ac44bca5e565f07b