### PR TITLE
Expand translate-documents helper matching for embedded stems

### DIFF
--- a/translate-documents.sh
+++ b/translate-documents.sh
@@ -550,7 +550,7 @@ find_related_output_file() {
             ts=$(stat -f %m "$file" 2>/dev/null || echo 0)
         fi
 
-        if [[ "$(basename "$file")" == "$base"* ]] && [ "$ts" -ge "$latest_ts" ]; then
+        if [[ "$(basename "$file")" == *"${base}"* ]] && [ "$ts" -ge "$latest_ts" ]; then
             latest_match="$file"
             latest_ts=$ts
         fi

--- a/translator/tests/test_translate_documents_script.py
+++ b/translator/tests/test_translate_documents_script.py
@@ -1,0 +1,24 @@
+import subprocess
+from pathlib import Path
+
+
+def test_find_related_output_file_accepts_embedded_stem(tmp_path):
+    base = "example"
+    fake_file = tmp_path / f"12345_{base}.md"
+    fake_file.write_text("# Test document\n")
+
+    script_path = Path(__file__).resolve().parents[2] / "translate-documents.sh"
+
+    command = (
+        f"source '{script_path}'"
+        f"; find_related_output_file '{tmp_path}' '{base}.pdf'"
+    )
+
+    result = subprocess.run(
+        ["bash", "-lc", command],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.stdout.strip() == str(fake_file)


### PR DESCRIPTION
## Summary
- update find_related_output_file to consider files whose basenames contain the source stem while retaining newest-file selection
- add a pytest smoke test that drops a fake markdown file with an embedded stem to ensure the helper finds it

## Testing
- pytest translator/tests/test_translate_documents_script.py
- bash -n translate-documents.sh

------
https://chatgpt.com/codex/tasks/task_e_68f0df37bf948331953c0e1e14db35e6