### PR TITLE
Update output file matching logic and add smoke test

### DIFF
--- a/quality_assurance/tests/find_related_output_file_smoke.sh
+++ b/quality_assurance/tests/find_related_output_file_smoke.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+source "${REPO_ROOT}/translate-documents.sh"
+
+base="sample"
+source_filename="${base}.pdf"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+older_file="${workdir}/${base}.md"
+newer_file="${workdir}/12345_${base}.md"
+
+touch "${older_file}"
+sleep 1
+touch "${newer_file}"
+
+result="$(find_related_output_file "${workdir}" "${source_filename}")"
+
+if [[ "${result}" != "${newer_file}" ]]; then
+    echo "Expected ${newer_file}, got ${result:-<empty>}" >&2
+    exit 1
+fi
+
+echo "Smoke test passed: ${result}"


### PR DESCRIPTION
## Summary
- update `find_related_output_file` to recognise source basenames appearing mid-filename and continue picking the newest markdown/text output
- ensure fallback handling only returns a file when one exists
- add a smoke test that creates `12345_${base}.md` and verifies it is selected

## Testing
- `quality_assurance/tests/find_related_output_file_smoke.sh`
- `bash -n translate-documents.sh`
- `shellcheck translate-documents.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f0f7fe4e0483319fdcc8624896718b