### PR TITLE
Fix QA finalization readiness flags

### DIFF
--- a/airflow/tests/test_quality_assurance_auto_correction.py
+++ b/airflow/tests/test_quality_assurance_auto_correction.py
@@ -485,3 +485,55 @@ def test_finalize_qa_process_marks_pipeline_ready(tmp_path):
     assert result['pipeline_ready'] is True
     assert result['auto_correction_status'] == 'completed'
     assert result['auto_correction_requires_manual_followup'] is False
+
+
+def test_full_qa_pass_sets_pipeline_ready_flag(tmp_path):
+    qa_report_path = tmp_path / "qa_full_report.json"
+    qa_report_path.write_text("{}", encoding="utf-8")
+
+    translated_file = tmp_path / "translated_full.md"
+    translated_text = "Translated content ready for production."
+    translated_file.write_text(translated_text, encoding="utf-8")
+
+    qa_session = {
+        'translated_content': translated_text,
+        'translated_file': str(translated_file),
+    }
+
+    comprehensive_report = {
+        'overall_score': 99.2,
+        'quality_passed': True,
+        'report_file': str(qa_report_path),
+        'all_issues': [],
+        'corrections_applied': 3,
+        'corrected_content': "Production-ready content.",
+        'level_scores': {
+            'level1_integrity': 1.0,
+            'level2_formatting': 1.0,
+            'level3_semantics': 1.0,
+            'level4_visual': 1.0,
+            'level5_auto_correction': 1.0,
+        },
+        'level_results': {
+            'level5_auto_correction': {
+                'status': 'completed',
+                'requires_manual_followup': False,
+                'partial_success': False,
+            }
+        },
+    }
+
+    context = {
+        'load_translated_document': qa_session,
+        'generate_comprehensive_qa_report': comprehensive_report,
+    }
+
+    result = quality_assurance.finalize_qa_process(
+        task_instance=DummyTaskInstance(context)
+    )
+
+    assert result['qa_completed'] is True
+    assert result['pipeline_ready'] is True
+    assert result['auto_correction_performed'] is True
+    assert result['corrections_applied'] == 3
+    assert result['issues_count'] == 0


### PR DESCRIPTION
## Summary
- compute QA completion and readiness flags before assembling the final result
- reuse the derived flags in the final QA payload to avoid self-references
- add a unit test covering a full QA pass where the pipeline becomes ready

## Testing
- pytest airflow/tests/test_quality_assurance_auto_correction.py

------
https://chatgpt.com/codex/tasks/task_e_68f10147ac58833182eb31afc64a8309