### PR TITLE
Add dependency guards and packaging improvements for QA pipeline

### DIFF
--- a/quality_assurance/__init__.py
+++ b/quality_assurance/__init__.py
@@ -1,0 +1,18 @@
+"""Quality assurance helpers exposed as a proper Python package.
+
+This module ensures that Airflow DAGs and auxiliary scripts can import the
+quality assurance utilities (for example ``quality_assurance.visual_diff_system``)
+without relying on implicit ``sys.path`` manipulation.  The file also exports a
+minimal public API to make intra-package imports explicit.
+"""
+
+from .visual_diff_system import VisualDiffSystem, VisualDiffConfig  # noqa: F401
+from .ast_comparator import ASTComparator, ASTComparisonConfig  # noqa: F401
+
+__all__ = [
+    "VisualDiffSystem",
+    "VisualDiffConfig",
+    "ASTComparator",
+    "ASTComparisonConfig",
+]
+

--- a/quality_assurance/dockerfile.qa
+++ b/quality_assurance/dockerfile.qa
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install -y \
     wget \
     git \
     unzip \
+    pandoc \
     # Библиотеки для обработки изображений и компьютерного зрения
     libopencv-dev \
     python3-opencv \
@@ -74,13 +75,13 @@ RUN mkdir -p /app/temp \
     && chown -R qa:qa /mnt/storage/models
 
 # Копируем исходный код приложения
-COPY quality_assurance/ocr_validator.py /app/
-COPY quality_assurance/visual_diff_system.py /app/
-COPY quality_assurance/ast_comparator.py /app/
-COPY quality_assurance/ssim_calculator.py /app/
-COPY quality_assurance/auto_corrector.py /app/
-COPY quality_assurance/content_validator.py /app/
-COPY quality_assurance/main.py /app/
+COPY quality_assurance /app/quality_assurance
+RUN set -eux; \
+    for module in /app/quality_assurance/*.py; do \
+        name="$(basename "$module")"; \
+        ln -s "quality_assurance/$name" "/app/$name"; \
+    done
+ENV PYTHONPATH="/app:${PYTHONPATH}"
 
 # Делаем модуль translator доступным для авто-корректора
 COPY translator /app/translator

--- a/quality_assurance/requirements-qa.txt
+++ b/quality_assurance/requirements-qa.txt
@@ -19,7 +19,7 @@ Pillow>=10.1.0
 # PDF Processing
 PyPDF2>=3.0.1
 pdfplumber>=0.10.3
-pymupdf>=1.23.0
+PyMuPDF>=1.23.0
 pdf2image>=1.16.3
 
 # Machine Learning


### PR DESCRIPTION
## Summary
- add explicit dependency checks in the QA DAG so visual and AST stages fail when required tooling is missing
- package the quality_assurance helpers and update the QA image to install pandoc while exposing the modules consistently
- refresh the QA requirements to use the canonical PyMuPDF package name

## Testing
- pytest airflow/tests/test_quality_assurance_auto_correction.py


------
https://chatgpt.com/codex/tasks/task_e_68f1079034ac8331b0c9527268edafdc